### PR TITLE
FEATURE: Docs for missing SDK endpoints

### DIFF
--- a/content/docs/reference/sdk/cli-resource-management.md
+++ b/content/docs/reference/sdk/cli-resource-management.md
@@ -2,7 +2,7 @@
 title = "CLI Resource Management"
 description = "Manage core Highlighter resources like cases, experiments, and workflows directly from the command line."
 date = 2025-03-05T08:00:00+00:00
-updated = 2025-03-05T08:00:00+00:00
+updated = 2026-04-02T00:00:00+00:00
 draft = false
 weight = 70
 sort_by = "weight"
@@ -16,28 +16,115 @@ top = false
 
 ## Overview
 
-The Highlighter CLI (`hl`) has been expanded to support lifecycle management of core system resources. This allows for "headless" operation, automation scripts, and cleanup tasks without needing to access the web interface.
+The Highlighter CLI (`hl`) supports lifecycle management of core system resources, allowing "headless" operation, automation scripts, and cleanup tasks without needing to access the web interface.
 
-You can now manage the following entities directly from your terminal:
+You can manage the following resources directly from your terminal:
 
 *   **Cases**: `hl case`
 *   **Entities**: `hl entity`
+*   **Task Definitions**: `hl task-definition`
+*   **Workflow Steps**: `hl step`
 *   **Workflows**: `hl workflow` & `hl workflow-order`
 *   **Experiments & Training**: `hl experiment`, `hl evaluation`, `hl training-run`
 *   **Pipelines**: `hl pipeline-instance`
 
-## Common Operations
-
-Most resource command groups support a `delete` operation for cleanup. Use the `--help` flag with any command to see available options.
+Use the `--help` flag with any command to see available options:
 
 ```bash
-hl case --help
-hl evaluation --help
+hl task-definition --help
+hl entity --help
+```
+
+## Task Definitions
+
+Task definitions configure how a machine assessment step processes data — which machine agent to use, the object class to create entities for, and how to map fields from the source file.
+
+```bash
+# List all task definitions
+hl task-definition list
+
+# Filter by task type
+hl task-definition list --task-type KmlToEntity::EntityDetection
+
+# Read a single task definition
+hl task-definition read --id <UUID>
+
+# Create a task definition
+hl task-definition create \
+  --name "Import Pole Entities" \
+  --task-type "KmlToEntity::EntityDetection" \
+  --object-class-id <OBJECT_CLASS_UUID> \
+  --entity-external-id-type "Pole" \
+  --entity-external-id-field-name "SITE_LABEL"
+
+# Delete a task definition
+hl task-definition delete --id <UUID>
+```
+
+Supported `--task-type` values:
+
+| Task Type | Description |
+|---|---|
+| `Review` | Human review step (no machine agent) |
+| `KmlToEntity::EntityDetection` | Import entities from KML files |
+| `DbfToEntity::EntityDetection` | Import entities from DBF (Shapefile attribute) files |
+
+## Workflow Orders
+
+Workflow orders group a batch of files to be processed through a workflow.
+
+```bash
+# List orders for a workflow
+hl workflow-order list --workflow-id <WORKFLOW_ID>
+
+# Create a new order
+hl workflow-order create \
+  --name "Site Survey Batch 1" \
+  --workflow-id <WORKFLOW_ID> \
+  --state approved
+
+# Create a draft order (files can be added before approving)
+hl workflow-order create \
+  --name "Pending Import" \
+  --workflow-id <WORKFLOW_ID> \
+  --state draft
+
+# Delete an order
+hl workflow-order delete --id <ORDER_ID>
+```
+
+The `--state` flag accepts `draft` or `approved` (default: `approved`).
+
+The optional `--case-matching-strategy` flag controls how files are matched to cases: `geolocation`, `ingestion_path`, or `none`.
+
+## Workflow Steps
+
+### Machine Assessment Steps
+
+Create a machine assessment step and automatically assign its agent based on the task definition:
+
+```bash
+hl step create-machine-assessment \
+  --name "DBF Entity Import" \
+  --workflow-id <WORKFLOW_ID> \
+  --task-definition-id <TASK_DEFINITION_UUID>
+```
+
+The agent is selected automatically from the task definition's `task_type` — no manual agent assignment required.
+
+To chain this step after an existing step:
+
+```bash
+hl step create-machine-assessment \
+  --name "DBF Entity Import" \
+  --workflow-id <WORKFLOW_ID> \
+  --task-definition-id <TASK_DEFINITION_UUID> \
+  --previous-step-id <PRECEDING_STEP_ID>
 ```
 
 ## Cases
 
-Manage the cases (tasks) within your workflows.
+Manage the cases within your workflows.
 
 ```bash
 # Create a new case
@@ -50,21 +137,41 @@ hl case delete --id <CASE_ID>
 hl case message create --case-id <CASE_ID> --content "Please review this."
 ```
 
-## Workflows & Orders
-
-Manage the structure of your projects.
+## Entities
 
 ```bash
+# List entities (default: 100 most recent)
+hl entity list
+
+# Filter and format
+hl entity list \
+  --object-class-uuid <UUID> \
+  --external-id-type Pole \
+  --limit 50 \
+  --format json
+
+# Count entities matching filters
+hl entity count
+hl entity count --external-id-type Pole
+hl entity count --object-class-uuid <UUID>
+
+# Delete an entity
+hl entity delete --id <ENTITY_ID>
+```
+
+`hl entity count` is useful for verifying the result of a bulk import without paging through all records.
+
+## Workflows
+
+```bash
+# List workflows
+hl workflow list
+
 # Delete a workflow
 hl workflow delete --id <WORKFLOW_ID>
-
-# Delete a workflow order
-hl workflow-order delete --id <ORDER_ID>
 ```
 
 ## Experiments & Research
-
-Manage your model development lifecycle.
 
 ### Experiments
 
@@ -77,8 +184,6 @@ hl experiment delete --id <EXPERIMENT_ID>
 ```
 
 ### Evaluations
-
-Evaluations support a rich set of commands for managing metrics and results.
 
 ```bash
 # List all evaluations
@@ -108,7 +213,12 @@ hl evaluation delete --id <EVALUATION_ID>
 
 ```bash
 # Create a training run
-hl training-run create --evaluation-id <EVAL_ID> --experiment-id <EXP_ID> --capability-id <MODEL_ID> --workflow-id <WORKFLOW_ID> --name "Run v1"
+hl training-run create \
+  --evaluation-id <EVAL_ID> \
+  --experiment-id <EXP_ID> \
+  --capability-id <MODEL_ID> \
+  --workflow-id <WORKFLOW_ID> \
+  --name "Run v1"
 
 # Read training run configuration
 hl training-run read <RUN_ID> -o config.yaml
@@ -120,14 +230,9 @@ hl training-run delete --id <RUN_ID>
 hl training-run artefact read --id <RUN_ID> --artefact-type OnnxOpset14 --save-path ./model.onnx
 ```
 
-## Entities & Pipelines
-
-Manage other core resources.
+## Pipelines
 
 ```bash
-# Delete an entity
-hl entity delete --id <ENTITY_ID>
-
 # Delete a pipeline instance
 hl pipeline-instance delete --id <INSTANCE_ID>
 ```

--- a/content/docs/user-manual/managing-workflows/cli-workflow-setup.md
+++ b/content/docs/user-manual/managing-workflows/cli-workflow-setup.md
@@ -1,0 +1,178 @@
++++
+title = "Setting Up a Workflow via CLI"
+description = "Create task definitions, machine assessment steps, and workflow orders entirely from the command line — no web UI required."
+date = 2026-04-02T00:00:00+00:00
+updated = 2026-04-02T00:00:00+00:00
+draft = false
+weight = 55
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "Automate workflow setup from the command line — useful for scripted deployments and repeatable data import pipelines."
+toc = true
+top = false
++++
+
+## Overview
+
+The Highlighter CLI (`hl`) lets you set up a complete machine import workflow without touching the web interface. This is particularly useful for:
+
+- Scripting repeatable import pipelines
+- Setting up workflows programmatically in CI/CD
+- Automating batch data ingestion
+
+This guide covers the full setup flow: creating a task definition, adding a machine assessment step to an existing workflow, creating a workflow order, and uploading files to trigger processing.
+
+## Prerequisites
+
+- `hl` CLI installed and configured (`hl --version`)
+- A profile set up in `~/.highlighter-profiles.yaml` (see [Highlighter Credentials](/docs/reference/sdk/highlighter-credentials/))
+- An existing workflow with a data source step
+- The UUID of the object class for entities you want to create
+
+## Step 1: Find Your Workflow
+
+```bash
+hl --profile myaccount workflow list
+```
+
+Note the `ID` of the workflow you want to add the machine step to.
+
+## Step 2: Create a Task Definition
+
+A task definition configures what the machine assessment step does — which machine agent runs, what object class to create entities for, and how to map fields from the source file.
+
+```bash
+hl --profile myaccount task-definition create \
+  --name "Import Pole Entities" \
+  --task-type "KmlToEntity::EntityDetection" \
+  --object-class-id <OBJECT_CLASS_UUID> \
+  --entity-external-id-type "Pole" \
+  --entity-external-id-field-name "SITE_LABEL"
+```
+
+Note the `id` from the response — you'll need it for the next step.
+
+### Supported task types
+
+| `--task-type` | Description |
+|---|---|
+| `KmlToEntity::EntityDetection` | Import entities from KML files |
+| `DbfToEntity::EntityDetection` | Import entities from DBF (Shapefile attribute) files |
+| `Review` | Human review (no machine agent) |
+
+### List existing task definitions
+
+```bash
+hl --profile myaccount task-definition list
+```
+
+## Step 3: Add a Machine Assessment Step
+
+```bash
+hl --profile myaccount step create-machine-assessment \
+  --name "Import Entities" \
+  --workflow-id <WORKFLOW_ID> \
+  --task-definition-id <TASK_DEFINITION_UUID>
+```
+
+The appropriate machine agent is assigned automatically from the task type. No manual agent selection is required.
+
+The response includes the new step ID. If you need to chain this step after another, use `--previous-step-id <STEP_ID>`.
+
+## Step 4: Create a Workflow Order
+
+A workflow order groups the files you want to process in this run.
+
+```bash
+hl --profile myaccount workflow-order create \
+  --name "Pole Import 2026-04" \
+  --workflow-id <WORKFLOW_ID> \
+  --state approved
+```
+
+Note the `id` from the response.
+
+To check existing orders for a workflow:
+
+```bash
+hl --profile myaccount workflow-order list --workflow-id <WORKFLOW_ID>
+```
+
+## Step 5: Upload Files and Trigger Processing
+
+Upload your data files to the data source and add them to the workflow order. The CLI will create cases and trigger the machine assessment tasks automatically:
+
+```bash
+# Upload files to the data source
+hl --profile myaccount data-file create \
+  --data-source-uuid <DATA_SOURCE_UUID> \
+  --data-file-dir ./my_files/
+
+# Add files to the workflow order (triggers processing)
+hl --profile myaccount task create \
+  --workflow-order-id <ORDER_ID> \
+  --file-ids <FILE_ID_1> <FILE_ID_2> ...
+```
+
+## Step 6: Verify Results
+
+After processing, check that entities were created:
+
+```bash
+# Count all entities of the expected type
+hl --profile myaccount entity count --external-id-type Pole
+
+# List the most recent entities
+hl --profile myaccount entity list \
+  --external-id-type Pole \
+  --limit 10
+```
+
+## Full Example Script
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="myaccount"
+WORKFLOW_ID="1234"
+OBJECT_CLASS_UUID="868bbe70-c549-42ed-be6e-fb65b8d52ebd"
+DATA_SOURCE_UUID="abc123"
+FILES_DIR="./import_files/"
+
+# 1. Create task definition
+TD=$(hl --profile "$PROFILE" task-definition create \
+  --name "Import Pole Entities $(date +%Y-%m)" \
+  --task-type "KmlToEntity::EntityDetection" \
+  --object-class-id "$OBJECT_CLASS_UUID" \
+  --entity-external-id-type "Pole" \
+  --entity-external-id-field-name "SITE_LABEL")
+
+TD_ID=$(echo "$TD" | python3 -c "import sys,json; print(json.load(sys.stdin)['taskDefinition']['id'])")
+echo "Created task definition: $TD_ID"
+
+# 2. Add machine assessment step
+hl --profile "$PROFILE" step create-machine-assessment \
+  --name "Import Entities" \
+  --workflow-id "$WORKFLOW_ID" \
+  --task-definition-id "$TD_ID"
+
+# 3. Create workflow order
+ORDER=$(hl --profile "$PROFILE" workflow-order create \
+  --name "Import $(date +%Y-%m-%d)" \
+  --workflow-id "$WORKFLOW_ID" \
+  --state approved)
+
+ORDER_ID=$(echo "$ORDER" | python3 -c "import sys,json; print(json.load(sys.stdin)['workflowOrder']['id'])")
+echo "Created order: $ORDER_ID"
+
+# 4. Upload files and trigger
+hl --profile "$PROFILE" data-file create \
+  --data-source-uuid "$DATA_SOURCE_UUID" \
+  --data-file-dir "$FILES_DIR"
+
+echo "Done. Check results with:"
+echo "  hl --profile $PROFILE entity count --external-id-type Pole"
+```

--- a/content/docs/user-manual/managing-workflows/cli-workflow-setup.md
+++ b/content/docs/user-manual/managing-workflows/cli-workflow-setup.md
@@ -102,18 +102,21 @@ hl --profile myaccount workflow-order list --workflow-id <WORKFLOW_ID>
 
 ## Step 5: Upload Files and Trigger Processing
 
-Upload your data files to the data source and add them to the workflow order. The CLI will create cases and trigger the machine assessment tasks automatically:
+Upload your data files to the data source, then add them to the workflow order. Adding files creates cases and triggers machine assessment tasks automatically:
 
 ```bash
 # Upload files to the data source
 hl --profile myaccount data-file create \
   --data-source-uuid <DATA_SOURCE_UUID> \
   --data-file-dir ./my_files/
+# Outputs a JSON map of local path → file ID
 
-# Add files to the workflow order (triggers processing)
+# Add files to the workflow order — this creates cases and triggers processing
+# (hl task create wraps the addFilesToWorkflowOrder mutation)
 hl --profile myaccount task create \
   --workflow-order-id <ORDER_ID> \
-  --file-ids <FILE_ID_1> <FILE_ID_2> ...
+  --file-ids <FILE_ID_1> \
+  --file-ids <FILE_ID_2>
 ```
 
 ## Step 6: Verify Results
@@ -142,6 +145,8 @@ OBJECT_CLASS_UUID="868bbe70-c549-42ed-be6e-fb65b8d52ebd"
 DATA_SOURCE_UUID="abc123"
 FILES_DIR="./import_files/"
 
+# Note: create commands always output JSON, so no --format flag is needed.
+
 # 1. Create task definition
 TD=$(hl --profile "$PROFILE" task-definition create \
   --name "Import Pole Entities $(date +%Y-%m)" \
@@ -168,10 +173,19 @@ ORDER=$(hl --profile "$PROFILE" workflow-order create \
 ORDER_ID=$(echo "$ORDER" | python3 -c "import sys,json; print(json.load(sys.stdin)['workflowOrder']['id'])")
 echo "Created order: $ORDER_ID"
 
-# 4. Upload files and trigger
-hl --profile "$PROFILE" data-file create \
+# 4. Upload files
+UPLOAD=$(hl --profile "$PROFILE" data-file create \
   --data-source-uuid "$DATA_SOURCE_UUID" \
-  --data-file-dir "$FILES_DIR"
+  --data-file-dir "$FILES_DIR")
+
+FILE_IDS=$(echo "$UPLOAD" | python3 -c "
+import sys, json
+m = json.load(sys.stdin)['data_file_path_to_id']
+print(' '.join(f'--file-ids {v}' for v in m.values()))
+")
+
+# 5. Add files to the workflow order — creates cases and triggers processing
+eval "hl --profile '$PROFILE' task create --workflow-order-id '$ORDER_ID' $FILE_IDS"
 
 echo "Done. Check results with:"
 echo "  hl --profile $PROFILE entity count --external-id-type Pole"


### PR DESCRIPTION
## Summary

Accompanying changes in HL: https://github.com/silverpond/highlighter/pull/1412

- Adds `hl task-definition` commands (list, read, create, delete) to the CLI Resource Management reference page
- Adds `hl workflow-order list` and `hl workflow-order create` commands
- Adds `hl step create-machine-assessment` command
- Adds `hl entity list` and `hl entity count` commands
- Adds a new how-to guide: **Setting Up a Workflow via CLI** — covers the full end-to-end flow from creating a task definition through to verifying entity import results, with a complete shell script example

## Context

These commands were implemented to fill gaps discovered while setting up a DBF entity import workflow. Previously, this required using the Rails runner or web UI for several steps (task definition creation, machine assessment step creation, workflow order management). All steps can now be scripted end-to-end via the CLI.