### PR TITLE
BUGFIX: Sh/bug/updated zola

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -30,3 +30,14 @@ jobs:
 
       - name: Validate Python code blocks
         run: nix develop --command python scripts/check-python-blocks.py
+
+  build:
+    name: Build site
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build site
+        run: nix develop --command zola build

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ public/
 **/.DS_Store
 
 .venv-check/
+
+.claude

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,7 @@ compile_sass = true
 
 # Whether to generate a feed file for the site
 generate_feeds = true
+feed_filenames = ["atom.xml"]
 
 # When set to "true", the generated HTML files are minified.
 minify_html = false

--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,7 @@ default_language = "en"
 compile_sass = true
 
 # Whether to generate a feed file for the site
-generate_feed = true
+generate_feeds = true
 
 # When set to "true", the generated HTML files are minified.
 minify_html = false
@@ -38,10 +38,9 @@ include_description = false
 include_content = true
 
 [markdown]
-# Whether to do syntax highlighting.
-# Theme can be customised by setting the `highlight_theme`
-# variable to a theme supported by Zola
-highlight_code = true
+
+[markdown.highlighting]
+theme = "github-dark"
 
 [extra]
 # Put all your custom variables here

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Highlighter Documentation"
 description = "Highlighter Documentation."
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 sort_by = "weight"
 weight = 1
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Docs"
 description = "Highlighter Documentation."
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 sort_by = "weight"
 weight = 1
 template = "docs/section.html"

--- a/content/docs/about/_index.md
+++ b/content/docs/about/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "About"
 description = "Managed services to help you get the most out of Highlighter"
-date = 2025-01-21T08:00:00+00:00
-updated = 2025-01-21T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 0

--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Reference"
 description = "Technical reference materials, APIs, and comprehensive guides for Highlighter"
-date = 2025-05-01T08:00:00+00:00
-updated = 2025-05-01T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 40

--- a/content/docs/reference/sdk/_index.md
+++ b/content/docs/reference/sdk/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Software Development Kit"
 description = "Documentation on the SDK"
-date = 2025-02-26T08:00:00+00:00
-updated = 2025-02-26T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 6

--- a/content/docs/user-manual/_index.md
+++ b/content/docs/user-manual/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "User Manual"
 description = ""
-date = 2025-01-21T08:00:00+00:00
-updated = 2025-01-21T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 30

--- a/content/docs/user-manual/agents/_index.md
+++ b/content/docs/user-manual/agents/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Develop and Manage Agents"
 description = "How to create, edit, and manage agents"
-date = 2025-05-01T08:00:00+00:00
-updated = 2025-05-01T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 40

--- a/content/docs/user-manual/assessing-and-labelling/_index.md
+++ b/content/docs/user-manual/assessing-and-labelling/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Assessing and Labelling Data"
 description = "How to Assess, label and annotate data in Highlighter"
-date = 2025-05-01T08:00:00+00:00
-updated = 2025-05-01T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 20

--- a/content/docs/user-manual/concepts/_index.md
+++ b/content/docs/user-manual/concepts/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Concepts"
 description = "Understanding the key concepts and principles behind Highlighter"
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/user-manual/data-management/_index.md
+++ b/content/docs/user-manual/data-management/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Data Management"
 description = "How to upload, import, and manage data in Highlighter"
-date = 2025-05-01T08:00:00+00:00
-updated = 2025-05-01T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 10

--- a/content/docs/user-manual/managing-workflows/_index.md
+++ b/content/docs/user-manual/managing-workflows/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Managing Workflows"
 description = ""
-date = 2025-01-21T08:00:00+00:00
-updated = 2025-01-21T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 30

--- a/content/docs/why-highlighter/_index.md
+++ b/content/docs/why-highlighter/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Why Highlighter"
 description = "Managed services to help you get the most out of Highlighter"
-date = 2025-01-21T08:00:00+00:00
-updated = 2025-01-21T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 10

--- a/content/docs/why-highlighter/quality-and-compliance/_index.md
+++ b/content/docs/why-highlighter/quality-and-compliance/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Quality and Compliance"
 description = "Highlighter's  quality and compliance frameworks"
-date = 2025-01-21T08:00:00+00:00
-updated = 2025-01-21T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 10

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "zola build"
 
 [build.environment]
-ZOLA_VERSION = "0.17.1"
+ZOLA_VERSION = "0.22.1"
 
 [context.deploy-preview]
 command = "zola build --base-url $DEPLOY_PRIME_URL"


### PR DESCRIPTION
## Summary

- Fix `config.toml` compatibility with Zola 0.22: rename `generate_feed` → `generate_feeds` and replace deprecated `highlight_code` with `[markdown.highlighting]`
- Remove `date` and `updated` fields from section `_index.md` front matter (no longer valid in Zola 0.22)
- Add `zola build` step to CI workflow to catch future breakage

## Background

Nixpkgs was pointed back to the master branch on 2026-03-30, which pulled in Zola 0.22.1. This version introduced breaking changes to config field names and section front matter.