### PR TITLE
Document the Operations Dashboard

### DIFF
--- a/content/docs/user-manual/operations-dashboard/_index.md
+++ b/content/docs/user-manual/operations-dashboard/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Operations Dashboard"
 description = "The Operate workspace for viewing, exploring, and acting on the data your assessment workflows produce — map, grid, and dashboard views, filtering, and case and order actions."
-date = 2026-06-19T08:00:00+00:00
-updated = 2026-06-19T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/user-manual/operations-dashboard/_index.md
+++ b/content/docs/user-manual/operations-dashboard/_index.md
@@ -1,0 +1,15 @@
++++
+title = "Operations Dashboard"
+description = "The Operate workspace for viewing, exploring, and acting on the data your assessment workflows produce — map, grid, and dashboard views, filtering, and case and order actions."
+date = 2026-06-19T08:00:00+00:00
+updated = 2026-06-19T08:00:00+00:00
+template = "docs/section.html"
+sort_by = "weight"
+weight = 5
+draft = false
++++
+
+The **Operations Dashboard** is the **Operate** workspace where you watch what
+your assessment workflows are producing and act on it. Start with the
+**Overview** for a tour, then dive into the detailed guides for views, finding
+data, working on the map, and acting on what you find.

--- a/content/docs/user-manual/operations-dashboard/exploring-data.md
+++ b/content/docs/user-manual/operations-dashboard/exploring-data.md
@@ -1,0 +1,57 @@
++++
+title = "Finding the data you need"
+description = "Narrow what the Operations Dashboard shows using scopes, a date range and timeline, search filters, saved-query layers, and map viewport filters."
+date = 2026-06-19T08:00:00+00:00
+updated = 2026-06-19T08:00:00+00:00
+draft = false
+weight = 3
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "Combine scopes, time, search filters, layers, and the map viewport to show exactly the data you care about."
+toc = true
+top = false
++++
+
+The Map and Grid show a filtered slice of your data. Several controls work
+together to narrow that slice.
+
+## Records and entities
+
+Two scope buttons control what the Map and Grid show:
+
+- **Records** — the source media (images, video, and other files) ingested by
+  your data sources.
+- **Entities** — the objects detected and tracked across that media, coloured
+  by object class.
+
+You can show records, entities, or both at once.
+
+## Date range and timeline
+
+- The **date range** picker in the top bar limits results to a time window.
+- Opening the **Timeline** strip shows when records and entities occur on two
+  tracks. **Drag** the selector to set the date range, use the **wheel** to
+  zoom, and **shift + wheel** to scroll through time.
+
+## Search and filters
+
+The **search** bar builds filter pills that narrow results by taxonomy and
+attributes — for example `class:` to match an object class or `condition:` to
+match an attribute condition. Typing in the search bar also filters the entity
+**Hierarchy** panel.
+
+## Layers
+
+Saved queries can be shown as toggleable map **layers**. Open the layers pane
+from the map toolbar to enable or hide each layer and adjust its **Layer
+settings**, letting you overlay or compare different slices of data.
+
+## Map viewport filters
+
+From the menu, the **Map Viewport Filters** let you restrict other surfaces to
+only what is currently inside the map view. You can independently apply the map
+viewport to the **grid**, the **hierarchy** (entity tree), **recordings**, the
+**timeline**, and **cases** — so panning and zooming the map narrows those
+panels too.

--- a/content/docs/user-manual/operations-dashboard/overview.md
+++ b/content/docs/user-manual/operations-dashboard/overview.md
@@ -1,0 +1,71 @@
++++
+title = "Overview"
+description = "Tour of the Operations Dashboard — the Operate workspace where you monitor live assessment data on a map, grid, and dashboard, inspect entities and records, and act on cases and orders."
+date = 2026-06-19T08:00:00+00:00
+updated = 2026-06-19T08:00:00+00:00
+draft = false
+weight = 1
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "The Operations Dashboard is the Operate workspace for viewing, exploring, and acting on the data flowing out of your assessment workflows."
+toc = true
+top = false
++++
+
+The **Operations Dashboard** is where you watch what your assessment workflows
+are producing and act on it. It brings the output of
+[Monitoring & Reporting](../../concepts/monitoring/) together with the live data,
+map, and case management in a single workspace.
+
+Open it from **Operate** in the top navigation, or go directly to
+`/monitor/operations`. Accounts can also be configured to land on the
+Operations Dashboard as their default home page.
+
+This page is a tour of the whole workspace. Each area has its own guide with
+more detail — follow the links as you go.
+
+## Views
+
+Controls at the top of the page switch the main area between three ways of
+looking at the same data — a **Map**, a **Grid** of thumbnails, and a
+**Dashboard** of summary tiles and worklists. See
+[Map, grid, and dashboard views](../views/).
+
+## Finding the data you need
+
+The data shown is narrowed by a few controls: the **Records** and **Entities**
+scopes, a **date range** and **timeline**, a **search** bar for building filter
+pills, saved-query **layers**, and **map viewport filters**. See
+[Finding the data you need](../exploring-data/).
+
+## Working on the map
+
+The map has a toolbar for panning the camera, box-selecting items, and placing
+or drawing new entities, plus an **Assess** action that opens the
+[Assessment Editor](../../assessing-and-labelling/) for the current view. See
+[Working on the map](../working-on-the-map/).
+
+## Selecting and acting
+
+Click an item to focus it and open its detail panel, or gather several items
+into a **multi-selection** to act on the group — **create a workflow order**,
+**merge** duplicate entities, or work through **cases**. See
+[Selecting and acting on items](../selecting-and-acting/).
+
+## Panels
+
+Panels can be opened around the main view and resized to suit your layout: the
+**Hierarchy** (entity tree), **Cases**, **Aggregated Summary**, **Recordings**,
+and the right-hand **detail panel**. Your current view, filters, and selection
+are kept in the page URL, so a dashboard state can be bookmarked or shared.
+
+## Related
+
+- [Monitoring & Reporting](../../concepts/monitoring/) — the concept behind the
+  data this dashboard surfaces.
+- [Managing Workflows](../../managing-workflows/) — creating the workflows,
+  orders, and cases you act on here.
+- [Assessing & Labelling](../../assessing-and-labelling/) — the editor reached
+  via the **Assess** action.

--- a/content/docs/user-manual/operations-dashboard/selecting-and-acting.md
+++ b/content/docs/user-manual/operations-dashboard/selecting-and-acting.md
@@ -1,0 +1,57 @@
++++
+title = "Selecting and acting on items"
+description = "Focus and inspect records, entities, and data sources, gather a multi-selection, and act on it — create a workflow order, merge entities, or work through cases."
+date = 2026-06-19T08:00:00+00:00
+updated = 2026-06-19T08:00:00+00:00
+draft = false
+weight = 5
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "Click an item to inspect it, gather several into a multi-selection, and act on the whole group."
+toc = true
+top = false
++++
+
+## Focusing versus selecting
+
+A single **click** on a record or entity *focuses* it: it opens that item's
+detail panel on the right. *Selecting* is separate — you build a
+**multi-selection** by box-selecting on the map, alt-clicking grid cards or tree
+rows, or adding items one at a time. Closing a detail panel clears the focus but
+leaves your selection intact.
+
+When more than one item is selected, the **Selected Items** panel appears on the
+right listing each item, and the status bar shows how many entities, records,
+and data sources are selected.
+
+## Detail panels
+
+The detail panel opens on the right for a **record**, **entity**, or **data
+source**. From it you can view and edit the item's details, jump to related
+items, locate the item on the map, and — for a data source — open its
+**recordings**.
+
+## Create a workflow order
+
+With one or more entities selected, **Create workflow order** opens a dialog
+that builds an order from the selection. Choose an **Object Class** and a
+**Workflow**, and optionally a **Name**. Only the selected entities of the
+chosen object class are added as cases, so a mixed selection is filtered down to
+the class you pick. See [Managing Workflows](../../managing-workflows/) for what
+happens to an order once it is created.
+
+## Merge entities
+
+When two or more entities are really the same thing, **Merge entities** combines
+them. A **survivor** is auto-selected (you can change it); annotations on the
+other entities are reassigned to the survivor, and the non-survivor entities are
+deleted. No entity is renamed. Because the non-survivors are removed, review the
+survivor choice before confirming the merge.
+
+## Cases
+
+The **Cases** panel lists the [cases](../../concepts/assessment-workflow/)
+relevant to the current data along with their status, so you can track and work
+through the items moving through your workflows without leaving the dashboard.

--- a/content/docs/user-manual/operations-dashboard/views.md
+++ b/content/docs/user-manual/operations-dashboard/views.md
@@ -1,0 +1,73 @@
++++
+title = "Map, grid, and dashboard views"
+description = "The three ways the Operations Dashboard shows your data — an interactive map, a grid of thumbnails, and a summary dashboard of tiles and worklists."
+date = 2026-06-19T08:00:00+00:00
+updated = 2026-06-19T08:00:00+00:00
+draft = false
+weight = 2
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "Switch the main area between a map, a grid of thumbnails, and a summary dashboard — three views of the same underlying data."
+toc = true
+top = false
++++
+
+The buttons at the top of the page switch the main area between three views.
+The **Map** and **Grid** buttons sit with the view tools on the right; the
+**Dashboard** button sits on the left next to the scope buttons. The Map and
+Grid show the same filtered results — the
+[scopes and filters](../exploring-data/) you choose apply to both.
+
+## Map view
+
+The Map plots geolocated **records** and detected **entities** on an
+interactive map. Entities are coloured by their object class, so you can read
+the spread of classes at a glance.
+
+- **Click** a marker to focus that item and open its
+  [detail panel](../selecting-and-acting/).
+- **Hover** a marker for a quick preview.
+- A tile-loading indicator shows while map imagery streams in.
+- The map toolbar lets you pan, box-select, and place or draw entities — see
+  [Working on the map](../working-on-the-map/).
+
+## Grid view
+
+The Grid shows the same results as a wall of thumbnail cards — a **Detection
+Gallery** for entities, or a **Records Gallery** for records. It is the quickest way
+to scan previews and pick items visually. The result count is shown in the
+header.
+
+- **Entity cards** show the entity name and its object class with a colour dot.
+- **Record cards** show the title and content type.
+- **Click** a card to focus it and open its detail panel; **double-click** a
+  record to open it.
+- Selected cards are marked with a tick. You can add cards to a
+  [multi-selection](../selecting-and-acting/) without opening them.
+- If nothing matches, the grid explains whether the query returned no results
+  or failed.
+
+## Dashboard view
+
+The Dashboard is an at-a-glance summary of recent activity and the work waiting
+for you. A **Refresh** control re-reads the latest figures.
+
+**Summary tiles** across the top cover recent activity, for example:
+
+- **Files uploaded** in the last 90 days.
+- **Assessments** in the last 90 days, split into Total, Human, and Machine.
+- **Tasks created** in the last 90 days, with Succeeded, Failed, and Active
+  Agents.
+- **Inventory** — Objects Tracked, Training Runs, Object Classes, and
+  Capabilities.
+
+**Worklists** below the tiles help you pick up work:
+
+- **My Assessment Tasks** — your queues, with the number of tasks available and
+  a **Start Task** action.
+- **Outstanding Human Assessments** — by process and step, showing the agents
+  assigned and progress.
+- **Machine Assessments** — active machine work by process and step, with task,
+  pending, and running counts.

--- a/content/docs/user-manual/operations-dashboard/working-on-the-map.md
+++ b/content/docs/user-manual/operations-dashboard/working-on-the-map.md
@@ -1,0 +1,48 @@
++++
+title = "Working on the map"
+description = "Use the Operations Dashboard map tools to pan and rotate the camera, box-select items, place or draw new entities, and assess the current view."
+date = 2026-06-19T08:00:00+00:00
+updated = 2026-06-19T08:00:00+00:00
+draft = false
+weight = 4
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+lead = "The map toolbar lets one tool own the map at a time — move the camera, select items, or add entities directly on the map."
+toc = true
+top = false
++++
+
+The map has a toolbar down its left edge. Only one tool is active at a time;
+choosing a tool deactivates the others. Each tool also has a keyboard shortcut.
+
+## Map tools
+
+- **Pan / rotate camera (h)** — the default. Drag to pan; **shift + drag** to
+  rotate. Use this to move around and frame an area.
+- **Select entities (q)** — drag a rectangle to box-select everything inside
+  it. Hold **alt** while selecting to add to the current selection instead of
+  replacing it. The selected items appear in the
+  [Selected Items panel](../selecting-and-acting/).
+- **Place point entity (w)** — click on the map to drop a new point entity.
+- **Draw polygon entity (e)** — draw a region to create a new entity with that
+  shape.
+- **Layers (r)** — open the layers pane to manage saved-query
+  [layers](../exploring-data/).
+
+Placing or drawing an entity creates it immediately and adds it to your data,
+ready to inspect or include in a workflow order.
+
+## Locating items
+
+Opening an item from another surface — a grid card, the entity tree, or a
+detail panel — can recentre and zoom the map to that item and briefly pulse its
+location so it is easy to spot.
+
+## Assessing the current view
+
+When you zoom in far enough, an **Assess** button appears over the map.
+It opens the [Assessment Editor](../../assessing-and-labelling/) loaded with
+everything inside the current map view and date range, so you can move straight
+from spotting something to assessing or labelling it.


### PR DESCRIPTION
Adds a new **Operations Dashboard** sub-section to the User Manual, documenting the `/monitor/operations` (Operate) workspace.

## Pages
- **Overview** — high-level tour of the workspace
- **Map, grid, and dashboard views** — the three views and what each shows
- **Finding the data you need** — scopes, date range & timeline, search filters, layers, map viewport filters
- **Working on the map** — map tools (pan, box-select, place/draw entity), locating, Assess view
- **Selecting and acting on items** — multi-selection, detail panels, create workflow order, merge entities, cases

Every user-facing claim was verified against a locally running hl-web instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)