### PR TITLE
Document Shadow Entities (step config + assessment editor)

### DIFF
--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -2,7 +2,7 @@
 title = "Working in the Assessment Editor"
 description = "Hone your skills in assessment Editor tools: use pointer, annotation, zoom, panels, and shortcuts to efficiently annotate and submit cases in Highlighter AI."
 date = 2023-09-26T08:00:00+00:00
-updated = 2023-09-26T08:00:00+00:00
+updated = 2026-06-25T08:00:00+00:00
 draft = false
 weight = 5
 sort_by = "weight"
@@ -62,6 +62,15 @@ Options stay set even after reloading the page, or moving to new cases or data f
 Show or hide all annotations/tracks (including associated text) by clicking the View menu, then "Show/hide annotations/tracks" (shortcut key 'f'). Hidden annotations/tracks are still submitted.
 
 What is the difference between annotations and tracks? If you are working with images for example, you will work with annotations. However if you are working with video for example, annotations are grouped together into tracks, that stretch over time.
+
+## Shadow Entities
+When a step has [shadow entities](../../managing-workflows/human-assessment-steps/#shadow-entities) configured, entities carried over from earlier steps that aren't relevant to your current task appear as faint "shadow" overlays rather than as normal annotations. They are kept out of the entities list and timeline and are not submitted, so you can focus on the entities that matter while still seeing the others for spatial context.
+
+You can interact with shadows in three ways:
+
+- **Reveal a shadow**: hover over a faint shadow overlay to temporarily show it, along with a "Shadow entity" label.
+- **Promote a shadow**: click a shadow to promote it into your working set. It becomes fully visible, appears in the entities list, and will be submitted. Only the entity you click is promoted.
+- **Shadow an entity yourself**: select one or more entities and press **Shift+S** (or choose "Shadow selected" from the menu) to move them out of your working set into the shadows.
 
 ## Submit Assessments
 Submit assessments by clicking the "Submit" button. Next to that button is a dropdown menu which has other options including "Skip" and "Flag and Submit".

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -64,11 +64,11 @@ Show or hide all annotations/tracks (including associated text) by clicking the 
 What is the difference between annotations and tracks? If you are working with images for example, you will work with annotations. However if you are working with video for example, annotations are grouped together into tracks, that stretch over time.
 
 ## Shadow Entities
-When a step has [shadow entities](../../managing-workflows/human-assessment-steps/#shadow-entities) configured, entities carried over from earlier steps that aren't relevant to your current task appear as faint "shadow" overlays rather than as normal annotations. They are kept out of the entities list and timeline and are not submitted, so you can focus on the entities that matter while still seeing the others for spatial context.
+When a step has [shadow entities](../../managing-workflows/human-assessment-steps/#shadow-entities) configured, entities carried over from earlier steps that aren't relevant to your current task are hidden on the canvas instead of being drawn as normal annotations. They are also kept out of the entities list and timeline and are not submitted, so the screen stays focused on the entities that matter — but the hidden ("shadowed") entities are still there if you need them.
 
 You can interact with shadows in three ways:
 
-- **Reveal a shadow**: hover over a faint shadow overlay to temporarily show it, along with a "Shadow entity" label.
+- **Reveal a shadow**: shadowed entities are invisible at rest. Hover over the spot on the canvas where one sits to temporarily reveal it, along with a "Shadow entity" label.
 - **Promote a shadow**: click a shadow to promote it into your working set. It becomes fully visible, appears in the entities list, and will be submitted. Only the entity you click is promoted.
 - **Shadow an entity yourself**: select one or more entities and press **Shift+S** (or choose "Shadow selected" from the menu) to move them out of your working set into the shadows.
 

--- a/content/docs/user-manual/managing-workflows/human-assessment-steps.md
+++ b/content/docs/user-manual/managing-workflows/human-assessment-steps.md
@@ -2,7 +2,7 @@
 title = "Human Assessment Steps"
 description = "Configure human assessment steps in Highlighter AI, assign contributors, configure queue settings, and monitor task progress for manual review workflows."
 date = 2025-05-01T08:00:00+00:00
-updated = 2025-11-19T08:00:00+00:00
+updated = 2026-06-25T08:00:00+00:00
 draft = false
 weight = 40
 sort_by = "weight"
@@ -41,6 +41,24 @@ When creating a human assessment step, you configure the following:
    - **Lockable**: Whether tasks can be locked for exclusive access
 
 > **Note**: Contributors work across all workflow step types using a unified interface. See [Assigning Contributors to Workflow Steps](../assigning-contributors/) for detailed assignment instructions.
+
+## Shadow Entities
+
+Shadow entities let you dim entities that aren't relevant to this step so contributors can focus on the task at hand, while still keeping potentially-useful inferences from earlier steps visible for context. Entities carried over from previous steps that don't match the step's **key attribute** rules appear as faint "shadow" overlays in the assessment editor instead of as normal annotations.
+
+When editing a human assessment step, configure shadow entities in the **Shadow Entities** section:
+
+1. Tick **Enable Shadow Entities** to turn the feature on for the step.
+2. Under **Key Attributes**, add one or more rules describing which entities are relevant:
+   - Click **+ Add Key Attribute** to add a rule.
+   - Choose an attribute from the dropdown.
+   - Optionally choose a specific value, or leave it as **Any value** to match any entity that has that attribute.
+   - Use the **×** button to remove a rule.
+3. Save the step.
+
+Rules combine with OR logic: an entity stays fully visible if it matches at least one rule, and entities matching no rule are shadowed. With the feature enabled but no rules configured, every carried-over entity is shadowed.
+
+Contributors can bring a shadowed entity back into their working set from the editor — see [Shadow Entities](../../assessing-and-labelling/working-in-the-assessment-editor/#shadow-entities) in *Working in the Assessment Editor*.
 
 ## Assigning Contributors
 

--- a/content/docs/user-manual/managing-workflows/human-assessment-steps.md
+++ b/content/docs/user-manual/managing-workflows/human-assessment-steps.md
@@ -48,7 +48,7 @@ Shadow entities let you hide entities that aren't relevant to this step so contr
 
 When editing a human assessment step, configure shadow entities in the **Shadow Entities** section:
 
-1. Tick **Enable Shadow Entities** to turn the feature on for the step.
+1. Select **Enable Shadow Entities** to turn the feature on for the step.
 2. Under **Key Attributes**, add one or more rules describing which entities are relevant:
    - Click **+ Add Key Attribute** to add a rule.
    - Choose an attribute from the dropdown.

--- a/content/docs/user-manual/managing-workflows/human-assessment-steps.md
+++ b/content/docs/user-manual/managing-workflows/human-assessment-steps.md
@@ -44,7 +44,7 @@ When creating a human assessment step, you configure the following:
 
 ## Shadow Entities
 
-Shadow entities let you hide entities that aren't relevant to this step so contributors can focus on the task at hand, while still keeping potentially-useful inferences from earlier steps accessible. Entities carried over from previous steps that don't match the step's **key attribute** rules are hidden in the assessment editor instead of being drawn as normal annotations — contributors can reveal an individual one by hovering over it.
+Shadow entities let you hide entities that aren't relevant to this step so contributors can focus on the task at hand, while still keeping potentially useful inferences from earlier steps accessible. Entities carried over from previous steps that don't match the step's **key attribute** rules are hidden in the assessment editor instead of being drawn as normal annotations — contributors can reveal an individual one by hovering over it.
 
 When editing a human assessment step, configure shadow entities in the **Shadow Entities** section:
 

--- a/content/docs/user-manual/managing-workflows/human-assessment-steps.md
+++ b/content/docs/user-manual/managing-workflows/human-assessment-steps.md
@@ -44,7 +44,7 @@ When creating a human assessment step, you configure the following:
 
 ## Shadow Entities
 
-Shadow entities let you dim entities that aren't relevant to this step so contributors can focus on the task at hand, while still keeping potentially-useful inferences from earlier steps visible for context. Entities carried over from previous steps that don't match the step's **key attribute** rules appear as faint "shadow" overlays in the assessment editor instead of as normal annotations.
+Shadow entities let you hide entities that aren't relevant to this step so contributors can focus on the task at hand, while still keeping potentially-useful inferences from earlier steps accessible. Entities carried over from previous steps that don't match the step's **key attribute** rules are hidden in the assessment editor instead of being drawn as normal annotations — contributors can reveal an individual one by hovering over it.
 
 When editing a human assessment step, configure shadow entities in the **Shadow Entities** section:
 


### PR DESCRIPTION
Documents the **Shadow Entities** feature added in silverpond/highlighter#1328.

- **Human Assessment Steps**: new "Shadow Entities" section — enabling the feature and configuring key-attribute rules (Enable Shadow Entities, Key Attributes, + Add Key Attribute, Any value, ×). Covers OR-matching and the enabled-but-no-rules behaviour.
- **Working in the Assessment Editor**: new "Shadow Entities" section — how shadowed entities appear (faint, off the entities list/timeline, not submitted) and how to reveal (hover), promote (click), or manually shadow (Shift+S).
- Cross-links the two pages.

Verified with the verifying-online-docs skill: every documented label was checked against the product's actual strings (the rendered step-config partial and the assessment-editor Go source), and `zola build` passes (validates the anchored cross-links).

Feature PR: silverpond/highlighter#1328
