### PR TITLE
Document selection and assessment deletion

### DIFF
--- a/content/docs/about/whats-new.md
+++ b/content/docs/about/whats-new.md
@@ -2,7 +2,7 @@
 title = "What's New in Highlighter"
 description = "Recent updates, new features, and improvements to Highlighter AI platform"
 date = 2025-11-19T08:00:00+00:00
-updated = 2025-11-19T08:00:00+00:00
+updated = 2026-07-13T08:00:00+00:00
 draft = false
 weight = 15
 sort_by = "weight"
@@ -13,6 +13,16 @@ lead = "Stay informed about the latest features, enhancements, and improvements 
 toc = true
 top = false
 +++
+
+## Consistent Selection and Safer Assessment Deletion
+
+**Release Date:** July 2026
+
+The Operations Dashboard and Assessment Editor now share the same Select interaction: click to replace a selection, Shift-click to toggle an item, drag to select intersecting shapes, and Shift-drag to add. The Assessment Editor also has a separate Hand tool for panning.
+
+Assessment deletion now includes **Delete Other Annotations** and **Delete Other Entities**. Every delete surface uses the same confirmation, protects active entity-level values that would otherwise lose their last annotation, and records a multi-annotation deletion as one undoable action.
+
+See [Working in the Assessment Editor](/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor/) and [Working on the Operations map](/docs/user-manual/operations-dashboard/working-on-the-map/).
 
 
 ## Taxon Group Import/Export Performance

--- a/content/docs/user-manual/assessing-and-labelling/video-labelling-shortcuts.md
+++ b/content/docs/user-manual/assessing-and-labelling/video-labelling-shortcuts.md
@@ -2,7 +2,7 @@
 title = "Video Labelling Shortcuts, Tools and Tips"
 description = "Boost video annotation efficiency in Highlighter AI with essential keyboard shortcuts, navigation tools, and productivity tips to speed up labelling and streamline workflows."
 date = 2025-05-01T08:00:00+00:00
-updated = 2025-05-01T08:00:00+00:00
+updated = 2026-07-13T08:00:00+00:00
 draft = false
 weight = 40
 sort_by = "weight"
@@ -20,6 +20,7 @@ See a summary of all keyboard shortcuts available in the Assessment Editor by ty
 
 ### Annotation Tool Shortcuts
 - **q**: Pointer/Selection tool
+- **h**: Hand/Pan tool
 - **w**: Bounding Box tool
 - **e**: Polygon tool
 - **r**: Brush tool
@@ -46,6 +47,8 @@ See a summary of all keyboard shortcuts available in the Assessment Editor by ty
 - **Shift + A**: Assign entity ID to selected tracks
 - **Ctrl + A**: Select all tracks that match similarity
 - **Delete/Backspace**: Delete selected tracks
+- **Shift + click**: Toggle one track in the selection
+- **Shift + drag with Select**: Add intersecting tracks to the selection
 
 ### Markers
 - **m**: Add marker at current time

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -73,8 +73,10 @@ The available actions depend on what is selected:
 - **Split view** is available for exactly two selected tracks from different files.
 - **Merge entities** combines directly selected entities by moving all of their tracks to one chosen survivor in the current assessment.
 - **Join** and **Union** retain their existing track operations and appear under the additional-actions menu when applicable.
+- **Selected files from submission** removes directly selected files from this submission. Tracks that exist only in those files are removed; tracks that continue in retained files are trimmed. If a removed track is the last holder of a stable entity value, you can preserve it on a surviving track before continuing.
+- **Selected entities** removes every annotation belonging to the directly selected entities from this submission.
 
-Destructive choices are grouped under **Delete** at the bottom of the panel. Each option shows the number of annotations and entities it will affect. Deletion still asks for confirmation and, when a stable entity value would otherwise be lost, lets you choose where to preserve that value.
+Destructive choices are grouped under **Delete** at the bottom of the panel. Each option shows the files, annotations, or entities it will affect. Deletion still asks for confirmation and, when a stable entity value would otherwise be lost, lets you choose where to preserve that value. Each confirmed action is one undo step.
 
 Assessment deletion changes the current submission: it removes annotations or
 removes a file from that submission. It does not permanently delete the

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -2,7 +2,7 @@
 title = "Working in the Assessment Editor"
 description = "Hone your skills in assessment Editor tools: use pointer, annotation, zoom, panels, and shortcuts to efficiently annotate and submit cases in Highlighter AI."
 date = 2023-09-26T08:00:00+00:00
-updated = 2026-06-24T08:00:00+00:00
+updated = 2026-07-13T08:00:00+00:00
 draft = false
 weight = 5
 sort_by = "weight"
@@ -18,6 +18,7 @@ Working in the Assessment Editor requires access to your tools
 - <a href="#use-assessment-editor-tools">Use Assessment Editor tools</a>
 - <a href="#access-the-file-list">Access The File List</a>
 - <a href="#access-the-objects-panel">Access The Objects Panel</a>
+- <a href="#delete-annotations-and-entities">Delete Annotations And Entities</a>
 - <a href="#edit-annotation-attributes">Edit Annotation Attributes</a>
 - <a href="#set-annotation-view-options">Set Annotation View Options</a>
 - <a href="#show-and-hide-annotations-tracks">Show And Hide Annotations/Tracks</a>
@@ -27,8 +28,18 @@ Working in the Assessment Editor requires access to your tools
 
 The assessment editor tools are laid out across in the top toolbar.
 
-### Use The Pointer Tool
-The most commonly used tool is the pointer tool (shortcut key: 'q'). This tool is used to move the canvas around.
+### Select Annotations
+
+Choose the Select tool (shortcut key: 'q') to select annotations while the media is paused:
+
+- Click an annotation to select it and clear the previous selection.
+- Hold Shift while clicking to add or remove one annotation from the selection.
+- Drag a rectangle to select every visible annotation shape it touches. Hold Shift while dragging to add the matches to the current selection.
+- Click empty space to clear the selection, or press Escape when you are not drawing or dragging a selection rectangle.
+
+### Pan The Canvas
+
+Choose the Hand tool (shortcut key: 'h'), then drag to move the canvas without changing the selection. The mouse wheel and zoom buttons continue to control zoom. In an editable assessment, Alt-drag a selected annotation while using the Select tool to move the annotation itself.
 
 ### Use The Annotation Tools
 The annotation tools are grouped into a dropdown. The first one is the Bounding Box Annotation tool (shortcut key: 'w'), allowing you to draw rectangles. Click once to start, move your mouse until you see the rectangle you want, then click again to stop.
@@ -47,6 +58,19 @@ Access the list of currently loaded files in your case by clicking the little pu
 
 ## Access the Objects Panel
 Access the objects panel using the little pull-out arrow at the right of the screen. Once open, click the little pull-in arrow to close again.
+
+## Delete Annotations And Entities
+
+Delete the current selection with Delete or Backspace, **Edit → Delete**, or the trash button beside an annotation in the Objects panel. The entity delete button removes every annotation in that entity.
+
+The Edit menu and canvas context menu also provide two bulk actions:
+
+- **Delete Other Annotations** keeps only the selected annotations, including when an entity is partly selected.
+- **Delete Other Entities** keeps every annotation belonging to an entity that has at least one selected annotation.
+
+Highlighter shows the number of affected annotations and entities before deleting. If the deletion would remove the last annotation holding an active entity-level value, the confirmation lists that value and lets you preserve it on a surviving annotation. Review any conflicting-value warning before confirming.
+
+The whole confirmed deletion is one action. Press Ctrl+Z once to restore all deleted annotations, preserved values, and the selection from before the command.
 
 ## Edit Annotation Attributes
 The Objects Panel lists the attributes of the selected annotation (or, for video, its track). To change them, open the attribute editor by clicking the "Edit" button at the bottom of the panel, or by pressing shortcut key 'i'.

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -2,7 +2,7 @@
 title = "Working in the Assessment Editor"
 description = "Hone your skills in assessment Editor tools: use pointer, annotation, zoom, panels, and shortcuts to efficiently annotate and submit cases in Highlighter AI."
 date = 2023-09-26T08:00:00+00:00
-updated = 2026-07-13T08:00:00+00:00
+updated = 2026-07-14T08:00:00+00:00
 draft = false
 weight = 5
 sort_by = "weight"
@@ -18,6 +18,7 @@ Working in the Assessment Editor requires access to your tools
 - <a href="#use-assessment-editor-tools">Use Assessment Editor tools</a>
 - <a href="#access-the-file-list">Access The File List</a>
 - <a href="#access-the-objects-panel">Access The Objects Panel</a>
+- <a href="#work-with-multiple-selected-items">Work With Multiple Selected Items</a>
 - <a href="#delete-annotations-and-entities">Delete Annotations And Entities</a>
 - <a href="#edit-annotation-attributes">Edit Annotation Attributes</a>
 - <a href="#set-annotation-view-options">Set Annotation View Options</a>
@@ -58,6 +59,27 @@ Access the list of currently loaded files in your case by clicking the little pu
 
 ## Access the Objects Panel
 Access the objects panel using the little pull-out arrow at the right of the screen. Once open, click the little pull-in arrow to close again.
+
+## Work With Multiple Selected Items
+
+When you select two or more files, annotations/tracks, or entities, the **Selected items** panel replaces the single-annotation Objects Panel on the right. Your current annotation focus is retained, so its attributes return when the selection is reduced to that one annotation again.
+
+Use the type buttons at the top of Selected items to choose which kind is listed and which actions are shown. This filters the panel only; it does not remove the other selected items. Scroll inside the item list to review larger selections, click a row to focus it, or use the × button to remove that item from the selection.
+
+The available actions depend on what is selected:
+
+- **Reassign tracks** moves only the directly selected tracks to a chosen entity. Other tracks belonging to their original entities stay where they are.
+- **New entity** moves the directly selected tracks to a new entity. With one annotation selected, the same action remains available in the Objects Panel header.
+- **Split view** is available for exactly two selected tracks from different files.
+- **Merge entities** combines directly selected entities by moving all of their tracks to one chosen survivor in the current assessment.
+- **Join** and **Union** retain their existing track operations and appear under the additional-actions menu when applicable.
+
+Destructive choices are grouped under **Delete** at the bottom of the panel. Each option shows the number of annotations and entities it will affect. Deletion still asks for confirmation and, when a stable entity value would otherwise be lost, lets you choose where to preserve that value.
+
+Assessment deletion changes the current submission: it removes annotations or
+removes a file from that submission. It does not permanently delete the
+account-wide file or entity records. Use Monitor Operations when you intend to
+delete those canonical records.
 
 ## Delete Annotations And Entities
 

--- a/content/docs/user-manual/operations-dashboard/selecting-and-acting.md
+++ b/content/docs/user-manual/operations-dashboard/selecting-and-acting.md
@@ -1,8 +1,8 @@
 +++
 title = "Selecting and acting on items"
-description = "Focus and inspect records, entities, and data sources, gather a multi-selection, and act on it — create a workflow order, merge entities, or work through cases."
+description = "Focus and inspect records, entities, and data sources, gather a multi-selection, and create, merge, or delete from it."
 date = 2026-06-19T08:00:00+00:00
-updated = 2026-07-13T08:00:00+00:00
+updated = 2026-07-14T08:00:00+00:00
 draft = false
 weight = 5
 sort_by = "weight"
@@ -49,6 +49,19 @@ them. A **survivor** is auto-selected (you can change it); annotations on the
 other entities are reassigned to the survivor, and the non-survivor entities are
 deleted. No entity is renamed. Because the non-survivors are removed, review the
 survivor choice before confirming the merge.
+
+## Delete selected records or entities
+
+Choose the **Records** or **Entities** type in **Selected Items**, then open
+**Delete** and choose **Selected records** or **Selected entities**. The command
+uses only the directly selected items of that type; items of another selected
+type are left alone.
+
+These Monitor Operations commands permanently delete the account-wide records
+or entities and their dependent data. Highlighter checks the complete selection
+before deleting it and asks for confirmation. If any selected item cannot be
+deleted, none of the batch is deleted and your selection remains available.
+Successful Monitor deletions cannot be undone.
 
 ## Cases
 

--- a/content/docs/user-manual/operations-dashboard/selecting-and-acting.md
+++ b/content/docs/user-manual/operations-dashboard/selecting-and-acting.md
@@ -2,7 +2,7 @@
 title = "Selecting and acting on items"
 description = "Focus and inspect records, entities, and data sources, gather a multi-selection, and act on it — create a workflow order, merge entities, or work through cases."
 date = 2026-06-19T08:00:00+00:00
-updated = 2026-06-19T08:00:00+00:00
+updated = 2026-07-13T08:00:00+00:00
 draft = false
 weight = 5
 sort_by = "weight"
@@ -18,7 +18,7 @@ top = false
 
 A single **click** on a record or entity *focuses* it: it opens that item's
 detail panel on the right. *Selecting* is separate — you build a
-**multi-selection** by box-selecting on the map, alt-clicking grid cards or tree
+**multi-selection** by box-selecting on the map, shift-clicking grid cards or tree
 rows, or adding items one at a time. Closing a detail panel clears the focus but
 leaves your selection intact.
 

--- a/content/docs/user-manual/operations-dashboard/working-on-the-map.md
+++ b/content/docs/user-manual/operations-dashboard/working-on-the-map.md
@@ -2,7 +2,7 @@
 title = "Working on the map"
 description = "Use the Operations Dashboard map tools to pan and rotate the camera, box-select items, place or draw new entities, and assess the current view."
 date = 2026-06-19T08:00:00+00:00
-updated = 2026-06-19T08:00:00+00:00
+updated = 2026-07-13T08:00:00+00:00
 draft = false
 weight = 4
 sort_by = "weight"
@@ -22,7 +22,7 @@ choosing a tool deactivates the others. Each tool also has a keyboard shortcut.
 - **Pan / rotate camera (h)** — the default. Drag to pan; **shift + drag** to
   rotate. Use this to move around and frame an area.
 - **Select entities (q)** — drag a rectangle to box-select everything inside
-  it. Hold **alt** while selecting to add to the current selection instead of
+  it. Hold **shift** while selecting to add to the current selection instead of
   replacing it. The selected items appear in the
   [Selected Items panel](../selecting-and-acting/).
 - **Place point entity (w)** — click on the map to drop a new point entity.


### PR DESCRIPTION
## Summary
- document Select and Hand tool behavior in the Assessment Editor
- document Delete Other scopes, stable-value rescue, and single-step undo
- update Operations Dashboard selection modifier from Alt to Shift

## Verification
- `zola build` (58 pages, 13 sections)