### PR TITLE
Document prev/next period buttons in assessment editor

### DIFF
--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -53,9 +53,9 @@ All tools allow you to zoom in and out using the scroll wheel of your mouse. You
 
 ## Navigate The Time Period
 
-The timeline bar at the bottom of the editor shows the current time period as a start and end time. Click either time to open the Time Range dialog and type specific datetimes, or use the chevron buttons beside the times to step back (`‹`) or forward (`›`) by one whole period. Each click shifts the window by its own duration (keeping periods contiguous) and reloads the tracks for the new window.
+The timeline bar at the bottom of the editor shows the current time period as a start and end time. Click either time to open the Time Range dialog and type specific dates and times, or use the chevron buttons beside the times to step back ('‹') or forward ('›') by one whole period. Each click shifts the window by its own duration (keeping periods contiguous) and reloads the tracks for the new window.
 
-In Live mode the `›` (next) button is disabled, since there is nothing after "now"; clicking `‹` (previous) exits Live mode and steps back to the previous period.
+In Live mode, the '›' (next) button is disabled, since there is nothing after "now"; clicking '‹' (previous) exits Live mode and steps back to the previous period.
 
 ## Access The File List
 Access the list of currently loaded files in your case by clicking the little pull-out arrow at the left of the screen. Once open, click the little pull-in arrow to close again. This can also be toggled using shortcut key 'l'.

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -16,6 +16,7 @@ top = false
 Working in the Assessment Editor requires access to your tools
 
 - <a href="#use-assessment-editor-tools">Use Assessment Editor tools</a>
+- <a href="#navigate-the-time-period">Navigate The Time Period</a>
 - <a href="#access-the-file-list">Access The File List</a>
 - <a href="#access-the-objects-panel">Access The Objects Panel</a>
 - <a href="#edit-annotation-attributes">Edit Annotation Attributes</a>
@@ -49,6 +50,12 @@ Once you have selected a tool within this group, it remains on top of the dropdo
 
 ### Zoom
 All tools allow you to zoom in and out using the scroll wheel of your mouse. You can also click the magnifying glass tools with the plus and minus inside.
+
+## Navigate The Time Period
+
+The timeline bar at the bottom of the editor shows the current time period as a start and end time. Click either time to open the Time Range dialog and type specific datetimes, or use the chevron buttons beside the times to step back (`‹`) or forward (`›`) by one whole period. Each click shifts the window by its own duration (keeping periods contiguous) and reloads the tracks for the new window.
+
+In Live mode the `›` (next) button is disabled, since there is nothing after "now"; clicking `‹` (previous) exits Live mode and steps back to the previous period.
 
 ## Access The File List
 Access the list of currently loaded files in your case by clicking the little pull-out arrow at the left of the screen. Once open, click the little pull-in arrow to close again. This can also be toggled using shortcut key 'l'.


### PR DESCRIPTION
Adds a "Navigate The Time Period" section to the Working in the Assessment Editor page documenting the new ‹/› chevron buttons beside the start/end time fields, which step the visible period back/forward by one window-width. Notes that in Live mode the next button is disabled and previous exits Live.