### PR TITLE
Document assessment Pan and Select tools

### DIFF
--- a/content/docs/user-manual/assessing-and-labelling/video-labelling-shortcuts.md
+++ b/content/docs/user-manual/assessing-and-labelling/video-labelling-shortcuts.md
@@ -2,7 +2,7 @@
 title = "Video Labelling Shortcuts, Tools and Tips"
 description = "Boost video annotation efficiency in Highlighter AI with essential keyboard shortcuts, navigation tools, and productivity tips to speed up labelling and streamline workflows."
 date = 2025-05-01T08:00:00+00:00
-updated = 2026-07-14T08:00:00+00:00
+updated = 2026-07-20T08:00:00+00:00
 draft = false
 weight = 40
 sort_by = "weight"
@@ -19,7 +19,8 @@ top = false
 See a summary of all keyboard shortcuts available in the Assessment Editor by typing **?** (Shift + /)
 
 ### Annotation Tool Shortcuts
-- **q**: Pointer/Selection tool
+- **q**: Select Annotation tool
+- **h**: Pan tool
 - **w**: Bounding Box tool
 - **e**: Polygon tool
 - **r**: Brush tool

--- a/content/docs/user-manual/assessing-and-labelling/video-labelling-shortcuts.md
+++ b/content/docs/user-manual/assessing-and-labelling/video-labelling-shortcuts.md
@@ -31,6 +31,8 @@ See a summary of all keyboard shortcuts available in the Assessment Editor by ty
 
 ### Navigation
 - **Spacebar**: Play/pause video
+- **Ctrl + drag** (Windows/Linux) or **Command + drag** (macOS): Temporarily pan from any annotation tool
+- **Middle-button drag**: Temporarily pan from any annotation tool
 - **Left/Right arrows**: Frame-by-frame navigation
 - **Shift + Left/Right**: Jump 1 second
 - **Alt + Left/Right**: Jump to previous/next marker

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -31,11 +31,11 @@ Working in the Assessment Editor requires access to your tools
 The assessment editor tools are laid out across in the top toolbar.
 
 ### Pan, Select, And Edit Annotations
-The Pan tool (shortcut key: 'h') is active when you open the editor. Drag the canvas to move around, or click an annotation to select it without opening its edit handles.
+The Pan tool (shortcut key: 'h') is active when you open the editor. Drag the canvas to move around, or click an annotation to select it without opening its edit handles. The canvas shows a hand cursor in Pan, changing to a pointer over annotations you can click.
 
 Use the Select Annotation tool (shortcut key: 'q') when you want to select or edit geometry. Click an annotation to select it, or drag across the canvas to select every annotation intersecting the rectangle. Hold Shift while clicking or rectangle-selecting to add annotations to the current selection. Selected annotation geometry exposes handles for direct editing.
 
-To move the canvas without leaving your current tool, hold Ctrl on Windows or Linux, or Command on macOS, while dragging. You can also drag with the middle mouse button. Temporary panning does not change the current selection or annotation geometry.
+To move the canvas without leaving your current tool, hold Ctrl on Windows or Linux, or Command on macOS, while dragging. You can also drag with the middle mouse button. While either temporary pan is engaged the cursor changes to the hand, and panning does not change the current selection or annotation geometry.
 
 ### Use The Annotation Tools
 The annotation tools are grouped into a dropdown. The first one is the Bounding Box Annotation tool (shortcut key: 'w'), allowing you to draw rectangles. Click once to start, move your mouse until you see the rectangle you want, then click again to stop.

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -35,6 +35,8 @@ The Pan tool (shortcut key: 'h') is active when you open the editor. Drag the ca
 
 Use the Select Annotation tool (shortcut key: 'q') when you want to select or edit geometry. Click an annotation to select it, or drag across the canvas to select every annotation intersecting the rectangle. Hold Shift while clicking or rectangle-selecting to add annotations to the current selection. Selected annotation geometry exposes handles for direct editing.
 
+To move the canvas without leaving your current tool, hold Ctrl on Windows or Linux, or Command on macOS, while dragging. You can also drag with the middle mouse button. Temporary panning does not change the current selection or annotation geometry.
+
 ### Use The Annotation Tools
 The annotation tools are grouped into a dropdown. The first one is the Bounding Box Annotation tool (shortcut key: 'w'), allowing you to draw rectangles. Click once to start, move your mouse until you see the rectangle you want, then click again to stop.
 

--- a/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
+++ b/content/docs/user-manual/assessing-and-labelling/working-in-the-assessment-editor.md
@@ -2,7 +2,7 @@
 title = "Working in the Assessment Editor"
 description = "Hone your skills in assessment Editor tools: use pointer, annotation, zoom, panels, and shortcuts to efficiently annotate and submit cases in Highlighter AI."
 date = 2023-09-26T08:00:00+00:00
-updated = 2026-07-14T08:00:00+00:00
+updated = 2026-07-20T08:00:00+00:00
 draft = false
 weight = 5
 sort_by = "weight"
@@ -30,8 +30,10 @@ Working in the Assessment Editor requires access to your tools
 
 The assessment editor tools are laid out across in the top toolbar.
 
-### Use The Pointer Tool
-The most commonly used tool is the pointer tool (shortcut key: 'q'). This tool is used to move the canvas around.
+### Pan, Select, And Edit Annotations
+The Pan tool (shortcut key: 'h') is active when you open the editor. Drag the canvas to move around, or click an annotation to select it without opening its edit handles.
+
+Use the Select Annotation tool (shortcut key: 'q') when you want to select or edit geometry. Click an annotation to select it, or drag across the canvas to select every annotation intersecting the rectangle. Hold Shift while clicking or rectangle-selecting to add annotations to the current selection. Selected annotation geometry exposes handles for direct editing.
 
 ### Use The Annotation Tools
 The annotation tools are grouped into a dropdown. The first one is the Bounding Box Annotation tool (shortcut key: 'w'), allowing you to draw rectangles. Click once to start, move your mouse until you see the rectangle you want, then click again to stop.


### PR DESCRIPTION
Document the separate Assessment Editor Pan and Select Annotation tools, including click selection in Pan, rectangle selection/editing in Select, and their keyboard shortcuts.